### PR TITLE
Rating by expertise FIX

### DIFF
--- a/src/main/java/br/edu/utfpr/servicebook/controller/ProfessionalHomeController.java
+++ b/src/main/java/br/edu/utfpr/servicebook/controller/ProfessionalHomeController.java
@@ -129,16 +129,15 @@ public class ProfessionalHomeController {
                 throw new InvalidParamsException("A especialidade profissional não foi encontrada. Por favor, tente novamente.");
             }
 
-//            Optional<Integer> professionalExpertiseRating = professionalExpertiseService.selectRatingByProfessionalAndExpertise(oProfessional.get().getId(), oExpertise.get().getId());
-            SidePanelProfessionalExpertiseRatingDTO sidePanelProfessionalExpertiseRatingDTO = SidePanelUtil.sidePanelProfessionalExpertiseRatingDTO( professionalExpertiseService.selectRatingByProfessionalAndExpertise(oProfessional.get().getId(), oExpertise.get().getId()));
+            mv.addObject("id", id.get());
+            Integer ratingOnExpertise = oProfessionalExpertise.get().getRating();
+            mv.addObject("professionalExpertiseRating", ratingOnExpertise);
+
             sidePanelItensDTO = SidePanelUtil.sidePanelItensDTO(
                     jobContractedService.countByProfessionalAndJobRequest_Expertise(oProfessional.get(), oExpertise.get()),
                     jobContractedService.countCommentsByProfessionalAndJobRequest_Expertise(oProfessional.get(), oExpertise.get()),
                     jobContractedService.countRatingByProfessionalAndJobRequest_Expertise(oProfessional.get(), oExpertise.get())
             );
-
-            mv.addObject("id", id.get());
-            mv.addObject("professionalExpertiseRating", sidePanelProfessionalExpertiseRatingDTO);
         }
         mv.addObject("dataIndividual", sidePanelItensDTO);
 

--- a/src/test/java/br/edu/utfpr/servicebook/controller/ProfessionalHomeControllerTest.java
+++ b/src/test/java/br/edu/utfpr/servicebook/controller/ProfessionalHomeControllerTest.java
@@ -1,0 +1,83 @@
+package br.edu.utfpr.servicebook.controller;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.web.servlet.ModelAndView;
+
+import javax.persistence.EntityNotFoundException;
+import java.util.Map;
+import java.util.Optional;
+
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("test")
+public class ProfessionalHomeControllerTest {
+    public static final Logger log =
+            LoggerFactory.getLogger(ProfessionalHomeControllerTest.class);
+    @Autowired
+    private ProfessionalHomeController controller;
+
+    @Test
+    @DisplayName("Deve detectar a propriedade 'professionalExpertiseRating' no ModelAndView retornado")
+    public void professionalHomeViewHasRatingByExpertiseProperty() {
+        try {
+            Long expertiseId = 2L;
+            ModelAndView mv = this.controller.showMyAccountProfessional(Optional.of(expertiseId));
+            Map<String, Object> modelObjects = mv.getModel();
+
+            Assertions.assertTrue(modelObjects.containsKey("professionalExpertiseRating"));
+            Object professionalExpertiseRating = modelObjects.get("professionalExpertiseRating");
+            Assertions.assertEquals("Integer", professionalExpertiseRating.getClass().getSimpleName());
+        } catch (Exception e) {
+            log.debug("TEST ERROR:" + e.getMessage());
+            Assertions.fail();
+        }
+    }
+
+    @Test
+    @DisplayName("Não deve detectar a propriedade 'professionalExpertiseRating' nas chamadas sem expertise_Id")
+    public void professionalHomeViewDoesntHaveRatingPropertyOnCallWithoutId() {
+        try {
+            ModelAndView mv = this.controller.showMyAccountProfessional(Optional.empty());
+            Map<String, Object> modelObjects = mv.getModel();
+            Assertions.assertFalse(modelObjects.containsKey("professionalExpertiseRating"));
+        } catch (Exception e) {
+            log.debug("TEST ERROR:" + e.getMessage());
+            Assertions.fail();
+        }
+    }
+
+    @Test
+    @DisplayName("Deve assegurar que método 'showMyAccountProfessional' lança exceção caso 'expertise.id' < 0")
+    public void showMyAccountProfessionalThrowsExceptionOnCallWithLessThanZeroId() {
+       Throwable exception = Assertions.assertThrows(Exception.class, () -> {
+            this.controller.showMyAccountProfessional(Optional.of(-2L));
+        });
+
+        Assertions.assertEquals(
+                "O identificador da especialidade não pode ser negativo. Por favor, tente novamente.",
+                exception.getMessage()
+        );
+    }
+
+    @Test
+    @DisplayName("Deve assegurar que método 'showMyAccountProfessional' lança exceção caso id aponte para entidade não existente")
+    public void showMyAccountProfessionalThrowsExceptionOnCallWithNonExistingExpertiseId() {
+        Long nonExistingExpertiseId = 500L;
+
+        Throwable exception = Assertions.assertThrows(EntityNotFoundException.class, () -> {
+            this.controller.showMyAccountProfessional(Optional.of(nonExistingExpertiseId));
+        });
+
+        Assertions.assertEquals(
+                "A especialidade não foi encontrada pelo id informado. Por favor, tente novamente.",
+                exception.getMessage()
+        );
+    }
+}


### PR DESCRIPTION
Essa PR incorpora um bug fixing.

Bug: Ao tentar acessar a rota “minha-conta/profissional” com o parâmetro “id” presente uma exceção era lançada descrevendo um erro de conversão de DTO para tipo numérico na renderização da view “professional/my-account”.

Fixing: Dentro da lógica do controller 'ProfessionalHomeController’ um DTO era incorporado como propriedade da view retornada, sendo que esta usa a propriedade diretamente em operações de comparação numérica. Pressupõe-se então que a intenção era passar o campo numérico guardado pelo DTO que faz referência ao ‘rating’ da especialidade.

Adições:

- A construção do DTO envolvia uma nova query para que se buscasse o rating por especialidade no banco de dados, porém, essa informação já existe no objeto ‘oProfessionalExpertise’ recuperado durante a validação do ID que compõe a rota, logo pode ser usado como o valor de propriedade na view.
- Testes foram adicionados para validar a existência e tipagem dessa propriedade na view retornada, detectando futuros erros de conversão como esse.