### PR TITLE
Adicionado confirmação de contratação do lado do profissional

### DIFF
--- a/src/main/java/br/edu/utfpr/servicebook/controller/JobCandidateController.java
+++ b/src/main/java/br/edu/utfpr/servicebook/controller/JobCandidateController.java
@@ -1,9 +1,6 @@
 package br.edu.utfpr.servicebook.controller;
 
-import br.edu.utfpr.servicebook.model.dto.IndividualMinDTO;
-import br.edu.utfpr.servicebook.model.dto.JobCandidateDTO;
-import br.edu.utfpr.servicebook.model.dto.JobCandidateMinDTO;
-import br.edu.utfpr.servicebook.model.dto.JobRequestMinDTO;
+import br.edu.utfpr.servicebook.model.dto.*;
 import br.edu.utfpr.servicebook.model.entity.Individual;
 import br.edu.utfpr.servicebook.model.entity.JobCandidate;
 import br.edu.utfpr.servicebook.model.entity.JobRequest;
@@ -15,6 +12,7 @@ import br.edu.utfpr.servicebook.service.JobCandidateService;
 import br.edu.utfpr.servicebook.service.JobRequestService;
 import br.edu.utfpr.servicebook.util.CurrentUserUtil;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -24,8 +22,12 @@ import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
 import javax.persistence.EntityNotFoundException;
+import java.io.IOException;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.Optional;
-import java.util.Set;
 
 @Controller
 @RequestMapping("/candidaturas")
@@ -90,6 +92,54 @@ public class JobCandidateController {
 
         jobCandidateService.delete(id, oindividual.get().getId());
         redirectAttributes.addFlashAttribute("msg", "Candidatura cancelada com sucesso!");
+
+        return "redirect:/minha-conta/profissional#emDisputa";
+    }
+
+    @PostMapping("/contratacao/{id}")
+    public String confirmHired(
+            @PathVariable Long id,
+            JobCandidateMinDTO dto,
+            RedirectAttributes redirectAttributes
+    ) throws IOException, ParseException {
+        String currentUserEmail = CurrentUserUtil.getCurrentUserEmail();
+
+        Optional<Individual> oindividual = individualService.findByEmail(currentUserEmail);
+        if(!oindividual.isPresent()){
+            throw new EntityNotFoundException("O usuário não foi encontrado!");
+        }
+
+        Optional<JobCandidate> oJobCandidate = jobCandidateService.findById(id, oindividual.get().getId());
+        if(!oJobCandidate.isPresent()) {
+            throw new EntityNotFoundException("Candidatura não encontrada!");
+        }
+
+        JobCandidate jobCandidate = oJobCandidate.get();
+        Optional<JobRequest> oJobRequest = jobRequestService.findById(jobCandidate.getJobRequest().getId());
+        if(!oJobRequest.isPresent()) {
+            throw new EntityNotFoundException("Pedido não encontrado!");
+        }
+
+        if (dto.getChosenByBudget().equals(true)) {
+            SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd");
+            jobCandidate.setHiredDate(formatter.parse(dto.getHiredDate()));
+
+            jobCandidate.setChosenByBudget(dto.getChosenByBudget());
+            jobCandidateService.save(jobCandidate);
+
+            JobRequest jobRequest = oJobRequest.get();
+            jobRequest.setStatus(JobRequest.Status.TO_DO);
+            jobRequestService.save(jobRequest);
+        } else {
+            jobCandidate.setChosenByBudget(dto.getChosenByBudget());
+            jobCandidateService.save(jobCandidate);
+
+            JobRequest jobRequest = oJobRequest.get();
+            jobRequest.setStatus(JobRequest.Status.BUDGET);
+            jobRequestService.save(jobRequest);
+        }
+
+        redirectAttributes.addFlashAttribute("msg", "Pedido salvo com sucesso!");
 
         return "redirect:/minha-conta/profissional#emDisputa";
     }

--- a/src/main/java/br/edu/utfpr/servicebook/controller/JobCandidateController.java
+++ b/src/main/java/br/edu/utfpr/servicebook/controller/JobCandidateController.java
@@ -141,6 +141,6 @@ public class JobCandidateController {
 
         redirectAttributes.addFlashAttribute("msg", "Pedido salvo com sucesso!");
 
-        return "redirect:/minha-conta/profissional#emDisputa";
+        return "redirect:/minha-conta/profissional/detalhes-servico/" + id;
     }
 }

--- a/src/main/java/br/edu/utfpr/servicebook/controller/ProfessionalHomeController.java
+++ b/src/main/java/br/edu/utfpr/servicebook/controller/ProfessionalHomeController.java
@@ -24,6 +24,8 @@ import org.springframework.web.servlet.ModelAndView;
 
 import javax.persistence.EntityNotFoundException;
 import javax.servlet.http.HttpServletRequest;
+import java.text.SimpleDateFormat;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -33,6 +35,8 @@ import java.util.stream.Collectors;
 public class ProfessionalHomeController {
 
     public static final Logger log = LoggerFactory.getLogger(ProfessionalHomeController.class);
+
+    private static final SimpleDateFormat dateFormat = new SimpleDateFormat("dd/MM/yyyy");
 
     @Autowired
     private IndividualService individualService;
@@ -519,6 +523,23 @@ public class ProfessionalHomeController {
         int percentCandidatesApplied = (int)(((double)currentCandidates / (double)maxCandidates) * 100);
 
         boolean isAvailableJobRequest = jb.getStatus().equals(JobRequest.Status.AVAILABLE) && jb.isClientConfirmation();
+        boolean isJobToHired = jb.getStatus().equals(JobRequest.Status.TO_HIRED);
+
+        Optional<JobCandidate> oJobCandidate = jobCandidateService.findById(id, oProfessional.get().getId());
+
+        if (oJobCandidate.isPresent()) {
+            JobCandidate jobCandidate = oJobCandidate.get();
+            boolean hasHiredDate = false;
+
+            if (jobCandidate.getHiredDate() != null) {
+                String date = this.dateFormat.format(jobCandidate.getHiredDate());
+                hasHiredDate = true;
+
+                mv.addObject("jobCandidateHiredDate",  date);
+            }
+
+            mv.addObject("hasHiredDate",  hasHiredDate);
+        }
 
         mv.addObject("job", jobFull);
         mv.addObject("client", client);
@@ -528,6 +549,7 @@ public class ProfessionalHomeController {
         mv.addObject("maxCandidates", maxCandidates);
         mv.addObject("percentCandidatesApplied", percentCandidatesApplied);
         mv.addObject("isAvailableJobRequest", isAvailableJobRequest);
+        mv.addObject("isJobToHired", isJobToHired);
         return mv;
     }
 

--- a/src/main/java/br/edu/utfpr/servicebook/model/dto/JobCandidateMinDTO.java
+++ b/src/main/java/br/edu/utfpr/servicebook/model/dto/JobCandidateMinDTO.java
@@ -13,6 +13,8 @@ public class JobCandidateMinDTO implements Serializable {
 
     private Long id;
     private String date;
+    private String hiredDate;
+    private Boolean chosenByBudget;
     private JobRequestFullDTO jobRequest;
 
 }

--- a/src/main/java/br/edu/utfpr/servicebook/model/entity/JobCandidate.java
+++ b/src/main/java/br/edu/utfpr/servicebook/model/entity/JobCandidate.java
@@ -5,7 +5,9 @@ package br.edu.utfpr.servicebook.model.entity;
 import javax.persistence.*;
 
 import lombok.*;
+import org.springframework.format.annotation.DateTimeFormat;
 
+import java.time.LocalDate;
 import java.util.Date;
 
 /**
@@ -30,6 +32,8 @@ public class JobCandidate {
 	private boolean chosenByBudget;
 
 	private Date date;
+
+	private Date hiredDate;
 
 	@ManyToOne
 	@MapsId("jobRequestId")

--- a/src/main/webapp/WEB-INF/view/professional/detail-service.jsp
+++ b/src/main/webapp/WEB-INF/view/professional/detail-service.jsp
@@ -106,13 +106,14 @@
                                         <form action="" method="post">
                                             <input type="hidden" name="_method" value="POST"/>
                                             <input id="chosenByBudget" name="chosenByBudget" type="hidden" value=""/>
+                                            <input class="col s6" type="date" id="hiredDateFormConfirmModal" name="hiredDate" hidden>
 
                                             <div class="modal-content" id="modal-content-confirm-hired" style="display: none">
                                                 <h5>Você tem certeza que deseja confirmar a contratação desse serviço?</h5>
 
                                                 <p class="no-margin"><strong>Descrição do serviço:</strong> ${job.description}</p>
                                                 <p class="no-margin"><strong>Cliente:</strong> ${client.name}</p>
-                                                <p class="no-margin"><strong>Data de realização:</strong> <input type="date" id="hiredDateFormConfirmModal" name="hiredDate" value=""></p>
+                                                <p class="no-margin"><strong>Data de realização:</strong> <span id="date-confirmed-span"></span></p>
                                             </div>
 
                                             <div class="modal-content" id="modal-content-not-confirm-hired" style="display: none">
@@ -195,6 +196,7 @@
 
         $('#hiredFormButton').click(function () {
             if ($("#confirmHired").is(":checked")) {
+                $("#date-confirmed-span").text($("#hiredDateFormConfirm").val());
                 $("#modal-content-confirm-hired").show();
                 $("#modal-content-not-confirm-hired").hide();
 
@@ -207,6 +209,5 @@
                 $("#chosenByBudget").val(false);
             }
         });
-
     });
 </script>

--- a/src/main/webapp/WEB-INF/view/professional/detail-service.jsp
+++ b/src/main/webapp/WEB-INF/view/professional/detail-service.jsp
@@ -73,7 +73,68 @@
                             </div>
 
                         </div>
+
+                        <c:if test="${isJobToHired}">
+                            <div class="row">
+                                <div class="col s12">
+                                    <p class="text-area-info-cli primary-color-text">Confirmação do serviço:</p>
+                                </div>
+
+                                <form id="hiredForm" method="post">
+                                    <label>
+                                        <input id="confirmHired" name="chosenByBudget" type="radio" value="true"/>
+                                        <span>Confirmo a realização do serviço</span>
+                                    </label>
+
+                                    <label>
+                                        <input id="notConfirmHired" name="chosenByBudget" type="radio" value="false"/>
+                                        <span>Não poderei realizar o serviço</span>
+                                    </label>
+
+                                    <div class="row" id="confirmHiredForm" style="display: none; margin-top: 15px">
+                                        <p>Adicione abaixo a data para a realização do serviço e confirme sua ação:</p>
+                                        <input class="col s6" type="date" id="hiredDateFormConfirm" name="hiredDate">
+                                    </div>
+
+                                    <div class="row">
+                                        <a id="hiredFormButton" href="#modal-confirm-hired" data-url="${pageContext.request.contextPath}/candidaturas/contratacao/${job.id}" class="waves-effect waves-light btn spacing-buttons modal-trigger">Contratação</a>
+                                    </div>
+                                </form>
+
+                                <div id="modal-confirm-hired" class="modal">
+                                    <div class="modal-content">
+                                        <form action="" method="post">
+                                            <input type="hidden" name="_method" value="POST"/>
+                                            <input id="chosenByBudget" name="chosenByBudget" type="hidden" value=""/>
+
+                                            <div class="modal-content" id="modal-content-confirm-hired" style="display: none">
+                                                <h5>Você tem certeza que deseja confirmar a contratação desse serviço?</h5>
+
+                                                <p class="no-margin"><strong>Descrição do serviço:</strong> ${job.description}</p>
+                                                <p class="no-margin"><strong>Cliente:</strong> ${client.name}</p>
+                                                <p class="no-margin"><strong>Data de realização:</strong> <input type="date" id="hiredDateFormConfirmModal" name="hiredDate" value=""></p>
+                                            </div>
+
+                                            <div class="modal-content" id="modal-content-not-confirm-hired" style="display: none">
+                                                <h4>Você tem certeza que deseja desistir da contratação desse serviço?</h4>
+                                            </div>
+                                            <div class="modal-footer">
+                                                <button type="button" class="modal-close btn-flat waves-effect waves-light btn btn-gray">Cancelar</button>
+                                                <button type="submit" class="modal-close btn waves-effect waves-light gray">Sim</button>
+                                            </div>
+                                        </form>
+                                    </div>
+                                </div>
+                            </div>
+                        </c:if>
+
                         <div class="row">
+                            <c:if test="${hasHiredDate}">
+                                <div class="col s12">
+                                    <p class="text-area-info-cli primary-color-text">Data de realização do serviço: ${jobCandidateHiredDate}</p>
+                                </div>
+                            </c:if>
+
                             <div class="col s12">
                                 <p class="text-area-info-cli primary-color-text">Descrição do serviço: ${job.description}</p>
                             </div>
@@ -103,3 +164,49 @@
 
     </jsp:body>
 </t:professional>
+
+<script>
+    $(document).ready(function() {
+        $('.modal').modal({
+            onOpenEnd: function (modal, trigger){
+                var url = $(trigger).data('url');
+                var name = $(trigger).data('name');
+
+                modal = $(modal);
+                var form = modal.find('form');
+                form.attr('action', url);
+                modal.find('#strong-name').text(name);
+            }
+
+        });
+
+        $('#hiredFormButton').attr("disabled", "disabled");
+
+        $('#confirmHired').click(function () {
+            $('#hiredFormButton').removeAttr("disabled");
+            $("#confirmHiredForm").show();
+        });
+
+        $('#notConfirmHired').click(function () {
+            $("#hiredDateFormConfirm").val(null);
+            $('#hiredFormButton').removeAttr("disabled");
+            $("#confirmHiredForm").hide();
+        });
+
+        $('#hiredFormButton').click(function () {
+            if ($("#confirmHired").is(":checked")) {
+                $("#modal-content-confirm-hired").show();
+                $("#modal-content-not-confirm-hired").hide();
+
+                let date = $("#hiredDateFormConfirm").val();
+                $("#hiredDateFormConfirmModal").val(date);
+                $("#chosenByBudget").val(true);
+            } else {
+                $("#modal-content-confirm-hired").hide();
+                $("#modal-content-not-confirm-hired").show();
+                $("#chosenByBudget").val(false);
+            }
+        });
+
+    });
+</script>

--- a/src/main/webapp/WEB-INF/view/professional/disputed-jobs-report.jsp
+++ b/src/main/webapp/WEB-INF/view/professional/disputed-jobs-report.jsp
@@ -66,6 +66,10 @@
                             <a href="" class="waves-effect waves-light btn spacing-buttons">
                                 Detalhes
                             </a>
+
+                            <c:if test="${job.hiredDate == null}">
+                                <a href="#modal-hired" data-url="${pageContext.request.contextPath}/candidaturas/contratacao/${job.jobRequest.id}" data-name="${city.name}" class="waves-effect waves-light btn spacing-buttons modal-trigger">Contratação</a>
+                            </c:if>
                             <a href="#modal-delete" data-url="${pageContext.request.contextPath}/candidaturas/${job.jobRequest.id}" data-name="${city.name}" class="waves-effect waves-light btn spacing-buttons red modal-trigger">Desistir</a>
                         </div>
                     </div>
@@ -85,6 +89,38 @@
                     <div class="modal-footer">
                         <button type="button" class="modal-close btn-flat waves-effect waves-light btn btn-gray">Cancelar</button>
                         <button type="submit" class="modal-close btn waves-effect waves-light gray">Sim</button>
+                    </div>
+                </form>
+            </div>
+        </div>
+
+        <div id="modal-hired" class="modal">
+            <div class="modal-content center" style="padding: 45px !important;">
+                <span id="confirmHiredButton" class="btn waves-effect waves-light gray">Confirmar contratação</span>
+                <span id="confirmNotHiredButton" class="btn-flat waves-effect waves-light btn btn-gray">Não aceitar contratação</span>
+                <form id="confirm-hired" action="" method="post" style="display: none">
+                    <input type="hidden" name="_method" value="POST"/>
+                    <input type="hidden" name="chosenByBudget" value="true"/>
+
+                    <div class="modal-content">
+                        <span>Adicione abaixo a data para a realização do serviço e confirme sua ação:</span>
+                        <input type="date" id="hired-date-form-confirm" name="hiredDate">
+                    </div>
+                    <div class="modal-footer">
+                        <button type="button" class="modal-close btn-flat waves-effect waves-light btn btn-gray">Cancelar</button>
+                        <button type="submit" class="modal-close btn waves-effect waves-light gray">Confirmar</button>
+                    </div>
+                </form>
+                <form id="confirm-not-hired" action="" method="post" style="display: none">
+                    <input type="hidden" name="_method" value="POST"/>
+                    <input type="hidden" name="chosenByBudget" value="false"/>
+
+                    <div class="modal-content">
+                        <span>Pedido será salvo como não contratado, confirme sua ação!</span>
+                    </div>
+                    <div class="modal-footer">
+                        <button type="button" class="modal-close btn-flat waves-effect waves-light btn btn-gray">Cancelar</button>
+                        <button type="submit" class="modal-close btn waves-effect waves-light gray">Confirmar</button>
                     </div>
                 </form>
             </div>
@@ -109,6 +145,16 @@
                 modal.find('#strong-name').text(name);
             }
 
+        });
+
+        $('#confirmHiredButton').click(function () {
+            $("#confirm-hired").show();
+            $("#confirm-not-hired").hide();
+        });
+
+        $('#confirmNotHiredButton').click(function () {
+            $("#confirm-not-hired").show();
+            $("#confirm-hired").hide();
         });
     });
 </script>

--- a/src/main/webapp/WEB-INF/view/professional/disputed-jobs-report.jsp
+++ b/src/main/webapp/WEB-INF/view/professional/disputed-jobs-report.jsp
@@ -66,10 +66,6 @@
                             <a href="minha-conta/profissional/detalhes-servico/${job.jobRequest.id}" class="waves-effect waves-light btn spacing-buttons">
                                 Detalhes
                             </a>
-
-                            <c:if test="${job.hiredDate == null}">
-                                <a href="#modal-hired" data-url="${pageContext.request.contextPath}/candidaturas/contratacao/${job.jobRequest.id}" data-name="${city.name}" class="waves-effect waves-light btn spacing-buttons modal-trigger">Contratação</a>
-                            </c:if>
                             <a href="#modal-delete" data-url="${pageContext.request.contextPath}/candidaturas/${job.jobRequest.id}" data-name="${city.name}" class="waves-effect waves-light btn spacing-buttons red modal-trigger">Desistir</a>
                         </div>
                     </div>
@@ -89,38 +85,6 @@
                     <div class="modal-footer">
                         <button type="button" class="modal-close btn-flat waves-effect waves-light btn btn-gray">Cancelar</button>
                         <button type="submit" class="modal-close btn waves-effect waves-light gray">Sim</button>
-                    </div>
-                </form>
-            </div>
-        </div>
-
-        <div id="modal-hired" class="modal">
-            <div class="modal-content center" style="padding: 45px !important;">
-                <span id="confirmHiredButton" class="btn waves-effect waves-light gray">Confirmar contratação</span>
-                <span id="confirmNotHiredButton" class="btn-flat waves-effect waves-light btn btn-gray">Não aceitar contratação</span>
-                <form id="confirm-hired" action="" method="post" style="display: none">
-                    <input type="hidden" name="_method" value="POST"/>
-                    <input type="hidden" name="chosenByBudget" value="true"/>
-
-                    <div class="modal-content">
-                        <span>Adicione abaixo a data para a realização do serviço e confirme sua ação:</span>
-                        <input type="date" id="hired-date-form-confirm" name="hiredDate">
-                    </div>
-                    <div class="modal-footer">
-                        <button type="button" class="modal-close btn-flat waves-effect waves-light btn btn-gray">Cancelar</button>
-                        <button type="submit" class="modal-close btn waves-effect waves-light gray">Confirmar</button>
-                    </div>
-                </form>
-                <form id="confirm-not-hired" action="" method="post" style="display: none">
-                    <input type="hidden" name="_method" value="POST"/>
-                    <input type="hidden" name="chosenByBudget" value="false"/>
-
-                    <div class="modal-content">
-                        <span>Pedido será salvo como não contratado, confirme sua ação!</span>
-                    </div>
-                    <div class="modal-footer">
-                        <button type="button" class="modal-close btn-flat waves-effect waves-light btn btn-gray">Cancelar</button>
-                        <button type="submit" class="modal-close btn waves-effect waves-light gray">Confirmar</button>
                     </div>
                 </form>
             </div>
@@ -145,16 +109,6 @@
                 modal.find('#strong-name').text(name);
             }
 
-        });
-
-        $('#confirmHiredButton').click(function () {
-            $("#confirm-hired").show();
-            $("#confirm-not-hired").hide();
-        });
-
-        $('#confirmNotHiredButton').click(function () {
-            $("#confirm-not-hired").show();
-            $("#confirm-hired").hide();
         });
     });
 </script>


### PR DESCRIPTION
Adicionado opção para o profissional confirmar que um pedido foi contratado.

Para testar:
Acessar /minha-conta/profissional#emDisputa > botão "contratação" nos pedidos (Ele pode confirmar a contratação e adicionar uma data para a realização ou pode também remover a contratação e o pedido volta para orçamento)